### PR TITLE
Feat: Add index.html frontend for the proxy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PHP Web Proxy</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background-color: #f4f7f9;
+            color: #333;
+        }
+        .container {
+            text-align: center;
+            background-color: #ffffff;
+            padding: 40px;
+            border-radius: 12px;
+            box-shadow: 0 8px 25px rgba(0,0,0,0.1);
+            width: 90%;
+            max-width: 600px;
+        }
+        h1 {
+            font-size: 2.5em;
+            margin-bottom: 20px;
+            color: #2c3e50;
+        }
+        p {
+            font-size: 1.1em;
+            color: #555;
+            margin-bottom: 30px;
+        }
+        .proxy-form {
+            display: flex;
+            border: 1px solid #ccc;
+            border-radius: 8px;
+            overflow: hidden;
+        }
+        .proxy-input {
+            flex-grow: 1;
+            border: none;
+            padding: 15px;
+            font-size: 1em;
+            outline: none;
+        }
+        .proxy-button {
+            border: none;
+            background-color: #3498db;
+            color: white;
+            padding: 0 25px;
+            font-size: 1em;
+            cursor: pointer;
+            transition: background-color 0.3s;
+        }
+        .proxy-button:hover {
+            background-color: #2980b9;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Web Proxy</h1>
+        <p>閲覧したいウェブサイトのURLを入力してください。</p>
+        <form action="proxy.php" method="GET" class="proxy-form">
+            <input type="text" name="url" class="proxy-input" placeholder="https://example.com" required>
+            <button type="submit" class="proxy-button">Go</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/proxy.php
+++ b/proxy.php
@@ -78,20 +78,8 @@ function proxy_for(string $url): string {
 $target_url_raw = $_GET['url'] ?? null;
 
 if (!$target_url_raw) {
-    // If no URL is provided, show a welcome page.
-    header('Content-Type: text/html; charset=utf-8');
-    echo "<!doctype html>
-    <html lang='en'>
-    <head>
-        <meta charset='utf-8'>
-        <title>PHP Proxy</title>
-        <style>body { font-family: sans-serif; text-align: center; padding: 4em; }</style>
-    </head>
-    <body>
-        <h1>Simple PHP Proxy</h1>
-        <p>Usage: <code>" . htmlspecialchars($_SERVER['PHP_SELF']) . "?url=https://example.com</code></p>
-    </body>
-    </html>";
+    // If no URL is provided, redirect to the main page (index.html).
+    header('Location: index.html');
     exit;
 }
 


### PR DESCRIPTION
This commit introduces an `index.html` file to provide a user-friendly interface for the PHP proxy.

- A new `index.html` file is created with a simple form where users can enter the URL they wish to visit.
- The `proxy.php` script is modified to redirect to `index.html` if it's accessed directly without a `?url=` parameter, improving usability.