### PR TITLE
Fix: Ensure correct Content-Type header is sent

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -177,6 +177,12 @@ foreach ($header_lines as $line) {
     header("$key: $value", false);
 }
 
+// Explicitly set the final Content-Type header to ensure the browser renders it correctly.
+// This is more reliable than forwarding it from the raw headers, especially after redirects.
+if ($content_type) {
+    header('Content-Type: ' . $content_type);
+}
+
 // 8. Rewrite the content body based on its type.
 $content_type_main = trim(explode(';', $content_type)[0]);
 


### PR DESCRIPTION
This commit fixes a critical bug where proxied pages were being displayed as raw code instead of rendered HTML in the browser.

The issue was caused by the proxy not reliably sending the `Content-Type` header to the client, especially after HTTP redirects. The browser would then default to treating the response as plain text.

The fix involves explicitly setting the `Content-Type` header using the value obtained from `curl_getinfo`. This is a more reliable method than forwarding the header from the raw response stream and ensures the browser always receives the correct content type for the final response.